### PR TITLE
【Fixed】Issue#50

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -43,6 +43,6 @@
 
 <h3><%= t('.cancel_my_account') %></h3>
 
-<p><%= t('.unhappy') %> <%= button_to t('.cancel_my_account'), registration_path(resource_name), data: { confirm: t('.are_you_sure') }, method: :delete %></p>
+<p><!-- <%= t('.unhappy') %> --> <%= button_to t('.cancel_my_account'), registration_path(resource_name), data: { confirm: t('.are_you_sure') }, method: :delete %></p>
 
 <%= link_to t('devise.shared.links.back'), :back %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -6,9 +6,9 @@
   <%= link_to t(".sign_up"), new_registration_path(resource_name) %><br />
 <% end %>
 
-<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+<!-- <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
   <%= link_to t(".forgot_your_password"), new_password_path(resource_name) %><br />
-<% end %>
+<% end %> -->
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
   <%= link_to t('.didn_t_receive_confirmation_instructions'), new_confirmation_path(resource_name) %><br />


### PR DESCRIPTION
### パスワードをお忘れの方への導線潰し（未実装のため）

- [x] views/devise/registrations/edit.hhtml.erb
- ``` <%= t('.unhappy') %> ``` 46行目を削除

### アカウント削除の「気に入らないですか」の文言削除
- [x] views/devise/shared/_links.html.erb
- ```  <%= link_to t(".forgot_your_password"), new_password_path(resource_name) %><br /> ``` 9〜11行目を削除